### PR TITLE
chore: add Dependabot configuration for Go modules and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: "chore(deps)"
+
+  - package-ecosystem: docker
+    directory: /docker
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "chore(docker)"


### PR DESCRIPTION
## Summary

Adds Dependabot configuration to keep Go module and Docker base image dependencies up to date. Matches the pattern used across other LayerV repos (qurl-service, nhp).

- **Go modules**: Weekly on Monday, groups minor+patch updates, limit 10 open PRs
- **Docker**: Weekly on Monday, limit 5 open PRs
- Commit message prefixes (`chore(deps)`, `chore(docker)`) for conventional commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)