### PR TITLE
chore(simplify): simplify recent changes in qurl-reverse-proxy

### DIFF
--- a/cmd/frpc/main.go
+++ b/cmd/frpc/main.go
@@ -25,7 +25,7 @@ import (
 	"github.com/denisbrodbeck/machineid"
 	toml "github.com/pelletier/go-toml/v2"
 
-	"github.com/OpenNHP/nhp-frp/pkg/version"
+	"github.com/OpenNHP/nhp-frp/pkg/banner"
 	_ "github.com/OpenNHP/nhp-frp/web/frpc" // register embedded admin dashboard assets
 	"github.com/OpenNHP/opennhp/endpoints/agent"
 	"github.com/fatedier/frp/cmd/frpc/sub"
@@ -34,24 +34,11 @@ import (
 )
 
 const (
-	colorReset  = "\033[0m"
-	colorGreen  = "\033[32m"
-	colorYellow = "\033[33m"
-	colorCyan   = "\033[36m"
-	colorBold   = "\033[1m"
+	colorReset  = banner.ColorReset
+	colorGreen  = banner.ColorGreen
+	colorYellow = banner.ColorYellow
+	colorCyan   = banner.ColorCyan
 )
-
-func printBanner() {
-	banner := `
-  _   _ _   _ ____        _____ ____  ____
- | \ | | | | |  _ \      |  ___|  _ \|  _ \
- |  \| | |_| | |_) |_____| |_  | |_) | |_) |
- | |\  |  _  |  __/______|  _| |  _ <|  __/
- |_| \_|_| |_|_|         |_|   |_| \_\_|
-`
-	fmt.Printf("%s%s%s%s", colorBold, colorCyan, banner, colorReset)
-	fmt.Printf("  %s%s (client)%s\n\n", colorGreen, version.Short(), colorReset)
-}
 
 // getMachineID returns a short unique identifier for the current machine
 func getMachineID() string {
@@ -60,6 +47,16 @@ func getMachineID() string {
 		return "unknown"
 	}
 	return id[:8]
+}
+
+// hasConfigFlag returns true if -c or --config was passed on the command line.
+func hasConfigFlag() bool {
+	for _, arg := range os.Args {
+		if arg == "-c" || arg == "--config" {
+			return true
+		}
+	}
+	return false
 }
 
 // getConfigFile returns the config file path from -c flag or defaults to "<binary_dir>/etc/frpc.toml"
@@ -129,26 +126,25 @@ func nhpAgentStart(waitCh chan error) {
 	}
 	exeDirPath := filepath.Dir(exeFilePath)
 
-	a := &agent.UdpAgent{}
+	udpAgent := &agent.UdpAgent{}
 
-	err = a.Start(exeDirPath, 4)
+	err = udpAgent.Start(exeDirPath, 4)
 	if err != nil {
 		fmt.Printf("\n  %s❌ Failed to start agent:%s %v\n\n", colorYellow, colorReset, err)
 		waitCh <- err
 		return
 	}
 
-	a.StartKnockLoop()
-	// react to terminate signals
+	udpAgent.StartKnockLoop()
+
 	termCh := make(chan os.Signal, 1)
 	signal.Notify(termCh, syscall.SIGTERM, os.Interrupt, syscall.SIGABRT)
 
-	// block until terminated
 	waitCh <- nil
 	<-termCh
 
 	fmt.Printf("\n  %s🛑 Shutting down agent...%s\n", colorYellow, colorReset)
-	a.Stop()
+	udpAgent.Stop()
 	fmt.Printf("  %s✅ Agent stopped gracefully%s\n\n", colorGreen, colorReset)
 
 	// Exit the entire process since sub.Execute() doesn't handle signals
@@ -170,7 +166,7 @@ func startHTTPServer(publicDir string) {
 }
 
 func main() {
-	printBanner()
+	banner.Print("client")
 
 	// Set binary directory and machine ID for FRP config template
 	exeBinDir := "."
@@ -194,31 +190,19 @@ func main() {
 
 	fmt.Printf("  nhp agent started successfully\n")
 
-	// Print config portal URL from frpc config
-	if cfgFile := getConfigFile(); cfgFile != "" {
-		printConfigPortal(cfgFile, machineID)
+	// Resolve config file once and ensure FRP uses it
+	cfgFile := getConfigFile()
+	printConfigPortal(cfgFile, machineID)
+	if !hasConfigFlag() {
+		os.Args = append(os.Args, "-c", cfgFile)
 	}
 
 	// Start built-in HTTP server for static files
-	exePath, _ := os.Executable()
-	publicDir := filepath.Join(filepath.Dir(exePath), "public")
+	publicDir := filepath.Join(exeBinDir, "public")
 	if info, err := os.Stat(publicDir); err == nil && info.IsDir() {
 		startHTTPServer(publicDir)
 	} else {
 		fmt.Printf("  %sWarning: public directory not found at %s, HTTP server not started%s\n", colorYellow, publicDir, colorReset)
-	}
-
-	// Ensure FRP uses the same config file we resolved
-	cfgFile := getConfigFile()
-	hasCFlag := false
-	for _, arg := range os.Args {
-		if arg == "-c" || arg == "--config" {
-			hasCFlag = true
-			break
-		}
-	}
-	if !hasCFlag {
-		os.Args = append(os.Args, "-c", cfgFile)
 	}
 
 	system.EnableCompatibilityMode()

--- a/cmd/frps/root.go
+++ b/cmd/frps/root.go
@@ -30,14 +30,8 @@ import (
 	"github.com/fatedier/frp/pkg/util/log"
 	"github.com/fatedier/frp/server"
 
+	"github.com/OpenNHP/nhp-frp/pkg/banner"
 	nhpversion "github.com/OpenNHP/nhp-frp/pkg/version"
-)
-
-const (
-	colorReset = "\033[0m"
-	colorGreen = "\033[32m"
-	colorCyan  = "\033[36m"
-	colorBold  = "\033[1m"
 )
 
 var (
@@ -48,18 +42,6 @@ var (
 
 	serverCfg v1.ServerConfig
 )
-
-func printBanner() {
-	banner := `
-  _   _ _   _ ____        _____ ____  ____
- | \ | | | | |  _ \      |  ___|  _ \|  _ \
- |  \| | |_| | |_) |_____| |_  | |_) | |_) |
- | |\  |  _  |  __/______|  _| |  _ <|  __/
- |_| \_|_| |_|_|         |_|   |_| \_\_|
-`
-	fmt.Printf("%s%s%s%s", colorBold, colorCyan, banner, colorReset)
-	fmt.Printf("  %s%s (server)%s\n\n", colorGreen, nhpversion.Short(), colorReset)
-}
 
 func init() {
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file of frps")
@@ -75,7 +57,7 @@ var rootCmd = &cobra.Command{
 	Use:   "nhp-frps",
 	Short: "nhp-frps is the server of nhp-frp (https://github.com/OpenNHP/nhp-frp)",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		printBanner()
+		banner.Print("server")
 
 		if showVersion {
 			fmt.Println(nhpversion.Full())
@@ -145,7 +127,7 @@ func Execute() {
 	}
 }
 
-func runServer(cfg *v1.ServerConfig) (err error) {
+func runServer(cfg *v1.ServerConfig) error {
 	log.InitLogger(cfg.Log.To, cfg.Log.Level, int(cfg.Log.MaxDays), cfg.Log.DisablePrintColor)
 
 	if cfgFile != "" {
@@ -160,5 +142,5 @@ func runServer(cfg *v1.ServerConfig) (err error) {
 	}
 	log.Infof("frps started successfully")
 	svr.Run(context.Background())
-	return
+	return nil
 }

--- a/pkg/banner/banner.go
+++ b/pkg/banner/banner.go
@@ -1,0 +1,29 @@
+package banner
+
+import (
+	"fmt"
+
+	"github.com/OpenNHP/nhp-frp/pkg/version"
+)
+
+const (
+	ColorReset  = "\033[0m"
+	ColorGreen  = "\033[32m"
+	ColorYellow = "\033[33m"
+	ColorCyan   = "\033[36m"
+	ColorBold   = "\033[1m"
+)
+
+const art = `
+  _   _ _   _ ____        _____ ____  ____
+ | \ | | | | |  _ \      |  ___|  _ \|  _ \
+ |  \| | |_| | |_) |_____| |_  | |_) | |_) |
+ | |\  |  _  |  __/______|  _| |  _ <|  __/
+ |_| \_|_| |_|_|         |_|   |_| \_\_|
+`
+
+// Print displays the NHP-FRP banner with the given role (e.g. "client" or "server").
+func Print(role string) {
+	fmt.Printf("%s%s%s%s", ColorBold, ColorCyan, art, ColorReset)
+	fmt.Printf("  %s%s (%s)%s\n\n", ColorGreen, version.Short(), role, ColorReset)
+}


### PR DESCRIPTION
## Summary

- **pkg/banner/banner.go** (new): Extract shared `printBanner()` and ANSI color constants from duplicated definitions in both client and server entry points
- **cmd/frpc/main.go**: Rename cryptic `a` → `udpAgent`, consolidate duplicate `getConfigFile()` calls, extract `hasConfigFlag()` helper, reuse `exeBinDir` for public dir path
- **cmd/frps/root.go**: Use shared `banner.Print()`, remove duplicate color constants and banner function, remove unnecessary named return in `runServer()`

## Notes

- No behavior changes — pure refactoring
- Pre-existing build issue: `cmd/frpc` cannot compile due to missing `third_party/opennhp/nhp` directory (transitive dependency). This is unrelated to these changes. `cmd/frps` and `pkg/` packages compile and pass `go vet` cleanly.
- No test files exist in the project, so verification was done via `go vet` and `gofmt`

## Test plan

- [ ] Verify `go vet ./pkg/...` and `go vet ./cmd/frps/` pass
- [ ] Verify `gofmt -l` reports no formatting issues
- [ ] Verify banner output unchanged for both client and server

🤖 Generated with [Claude Code](https://claude.com/claude-code)