### PR TITLE
feat(ci): add CODEOWNERS and dependency age-gate scaffold

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# CODEOWNERS - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# Default owners for everything
+* @layervai/platform
+
+# CI and repo config require platform team review
+/.github/ @layervai/platform
+/.github/workflows/ @layervai/platform

--- a/.github/workflows/dependency-age-check-actions.yml
+++ b/.github/workflows/dependency-age-check-actions.yml
@@ -1,0 +1,16 @@
+# Dependency Age Check (GitHub Actions pins)
+# Thin shim calling shared reusable workflow.
+name: Dependency Age Check (Actions)
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  workflow_dispatch:
+
+jobs:
+  age-check:
+    uses: layervai/ops-routines/.github/workflows/age-check-actions.yml@main
+    permissions:
+      contents: read


### PR DESCRIPTION
## Summary

Phase 0 scaffold for replacing Dependabot with Claude Routines-driven dependency automation across the LayerV fleet. Orchestration code lives in [layervai/ops-routines](https://github.com/layervai/ops-routines).

## What this PR adds

Each `dependency-age-check-*.yml` is a thin shim calling a shared reusable workflow in `layervai/ops-routines`. The workflow rejects PRs that introduce dependencies published in the last 7 days (14 days for Docker base images) unless the PR carries the `age-check-bypass` label.

The `age-check-bypass` label is applied **only** by `layervai/ops-routines/.github/workflows/cve-verify.yml` after a deterministic verification chain (OSV + GHSA cross-reference, severity >= HIGH, publisher-continuity check). Claude never decides the bypass.

If this PR adds a `.github/CODEOWNERS`, it designates `@layervai/platform` as the default owner and explicitly requires platform review on `.github/**`, which was flagged by the Phase 0 security review.

## Why

The security review of the Dependabot-replacement plan required age-gate coverage on every ecosystem the routine will touch AND CODEOWNERS on every `.github/**` path, before the pilot can start.

## Test plan

- [x] Commit GPG-signed
- [ ] CI green
- [ ] Reusable workflow resolves once the GitHub App is installed on this repo
- [ ] Age-check fires on a follow-up PR that modifies the relevant manifest

Related plan: see `layervai/ops-routines/runbooks/phase-0-checklist.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)